### PR TITLE
[SRK-70] Don't output extra spaces at the end of lines

### DIFF
--- a/Export.hs
+++ b/Export.hs
@@ -116,10 +116,12 @@ formatExportMap ytExport issueInfos hm =
         ]
   where
     longestTableLine = if T.null prettyTable then 0 else maximum (map T.length $ T.lines prettyTable)
-    prettyTable = T.pack $ B.render $
-         B.hsep 2 B.left $
-         map (B.vcat B.left)
-         tableContents
+    prettyTable =
+        T.unlines . map T.stripEnd . T.lines . T.pack $
+        B.render $
+            B.hsep 2 B.left $
+            map (B.vcat B.left)
+            tableContents
 
     tableContents
       | ytExport =


### PR DESCRIPTION
Extra spaces lead to ugly blank lines in Slack:

![image](https://user-images.githubusercontent.com/1523306/29089579-5f83f492-7c85-11e7-8313-2b7122cb52cc.png)
